### PR TITLE
Update to perspective 3.8.0

### DIFF
--- a/build.js
+++ b/build.js
@@ -16,7 +16,7 @@ const DEFAULT_BUILD = {
 
 /**
  * An `esbuild` plugin to mark `node_modules` dependencies as external.
- * @returns 
+ * @returns
  */
 function NodeModulesExternal(whitelist) {
   function setup(build) {

--- a/build.js
+++ b/build.js
@@ -1,10 +1,50 @@
-const {
-  NodeModulesExternal,
-} = require("@finos/perspective-esbuild-plugin/external");
-const { build } = require("@finos/perspective-esbuild-plugin/build");
 const { BuildCss } = require("@prospective.co/procss/target/cjs/procss.js");
 const fs = require("fs");
 const path_mod = require("path");
+const esbuild = require("esbuild");
+
+const DEFAULT_BUILD = {
+  target: ["es2022"],
+  bundle: true,
+  minify: !process.env.PSP_DEBUG,
+  sourcemap: true,
+  metafile: true,
+  entryNames: "[name]",
+  chunkNames: "[name]",
+  assetNames: "[name]",
+};
+
+/**
+ * An `esbuild` plugin to mark `node_modules` dependencies as external.
+ * @returns 
+ */
+function NodeModulesExternal(whitelist) {
+  function setup(build) {
+    build.onResolve({ filter: /^[A-Za-z0-9\@]/ }, (args) => {
+      return {
+        path: args.path,
+        external: true,
+        namespace: "skip-node-modules",
+      };
+    });
+  }
+
+  return {
+    name: "node_modules_external",
+    setup,
+  };
+}
+
+/**
+ * A build convenienve wrapper.
+ * @param {any} config An `esbuild.build` config.
+ */
+async function build(config) {
+  await esbuild.build({
+    ...DEFAULT_BUILD,
+    ...config,
+  });
+}
 
 const BUILD = [
   {

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -1,18 +1,6 @@
 <!doctype html>
 <html>
   <head>
-    <script
-      type="module"
-      src="../node_modules/@finos/perspective/dist/cdn/perspective.js"
-    ></script>
-    <script
-      type="module"
-      src="../node_modules/@finos/perspective-viewer/dist/cdn/perspective-viewer.js"
-    ></script>
-    <script
-      type="module"
-      src="../dist/cdn/perspective-viewer-summary.js"
-    ></script>
     <link
       rel="stylesheet"
       href="../node_modules/@finos/perspective-viewer/dist/css/themes.css"

--- a/examples/headers-modern.html
+++ b/examples/headers-modern.html
@@ -1,18 +1,6 @@
 <!doctype html>
 <html>
   <head>
-    <script
-      type="module"
-      src="../node_modules/@finos/perspective/dist/cdn/perspective.js"
-    ></script>
-    <script
-      type="module"
-      src="../node_modules/@finos/perspective-viewer/dist/cdn/perspective-viewer.js"
-    ></script>
-    <script
-      type="module"
-      src="../dist/cdn/perspective-viewer-summary.js"
-    ></script>
     <link
       rel="stylesheet"
       href="../node_modules/@finos/perspective-viewer/dist/css/themes.css"

--- a/examples/headers.html
+++ b/examples/headers.html
@@ -1,18 +1,6 @@
 <!doctype html>
 <html>
   <head>
-    <script
-      type="module"
-      src="../node_modules/@finos/perspective/dist/cdn/perspective.js"
-    ></script>
-    <script
-      type="module"
-      src="../node_modules/@finos/perspective-viewer/dist/cdn/perspective-viewer.js"
-    ></script>
-    <script
-      type="module"
-      src="../dist/cdn/perspective-viewer-summary.js"
-    ></script>
     <link
       rel="stylesheet"
       href="../node_modules/@finos/perspective-viewer/dist/css/themes.css"

--- a/examples/load-viewer-csv.js
+++ b/examples/load-viewer-csv.js
@@ -1,9 +1,11 @@
+import "../node_modules/@finos/perspective-viewer/dist/cdn/perspective-viewer.js";
+import "../dist/cdn/perspective-viewer-summary.js";
 import * as perspective from "../node_modules/@finos/perspective/dist/cdn/perspective.js";
 
 async function load() {
   let resp = await fetch("superstore.csv");
   let csv = await resp.text();
-  const worker = perspective.worker();
+  const worker = await perspective.worker();
   const table = worker.table(csv);
   const viewers = document.querySelectorAll("perspective-viewer");
   viewers.forEach(async (viewer) => {

--- a/examples/load-workspace.js
+++ b/examples/load-workspace.js
@@ -1,3 +1,6 @@
+import "../node_modules/@finos/perspective-viewer/dist/cdn/perspective-viewer.js";
+import "../node_modules/@finos/perspective-workspace/dist/cdn/perspective-workspace.js";
+import "../dist/cdn/perspective-viewer-summary.js";
 import * as perspective from "../node_modules/@finos/perspective/dist/cdn/perspective.js";
 
 const workspace = document.getElementById("workspace");
@@ -134,8 +137,8 @@ const DEFAULT_LAYOUT = {
 async function load() {
   let resp = await fetch("superstore.csv");
   let csv = await resp.text();
-  const worker = perspective.shared_worker();
-  workspace.tables.set("superstore", await worker.table(csv));
+  const worker = await perspective.worker();
+  workspace.addTable("superstore", worker.table(csv));
   workspace.restore(DEFAULT_LAYOUT);
 }
 

--- a/examples/themes.html
+++ b/examples/themes.html
@@ -1,18 +1,6 @@
 <!doctype html>
 <html>
   <head>
-    <script
-      type="module"
-      src="../node_modules/@finos/perspective/dist/cdn/perspective.js"
-    ></script>
-    <script
-      type="module"
-      src="../node_modules/@finos/perspective-viewer/dist/cdn/perspective-viewer.js"
-    ></script>
-    <script
-      type="module"
-      src="../dist/cdn/perspective-viewer-summary.js"
-    ></script>
     <link
       rel="stylesheet"
       href="../node_modules/@finos/perspective-viewer/dist/css/themes.css"

--- a/examples/workspace.html
+++ b/examples/workspace.html
@@ -1,25 +1,9 @@
 <!doctype html>
 <html>
   <head>
-    <script
-      type="module"
-      src="../node_modules/@finos/perspective/dist/cdn/perspective.js"
-    ></script>
-    <script
-      type="module"
-      src="../node_modules/@finos/perspective-viewer/dist/cdn/perspective-viewer.js"
-    ></script>
-    <script
-      type="module"
-      src="../node_modules/@finos/perspective-workspace/dist/cdn/perspective-workspace.js"
-    ></script>
-    <script
-      type="module"
-      src="../dist/cdn/perspective-viewer-summary.js"
-    ></script>
     <link
       rel="stylesheet"
-      href="../node_modules/@finos/perspective-viewer/dist/css/themes.css"
+      href="../node_modules/@finos/perspective-viewer/dist/css/pro-dark.css"
     />
     <link
       rel="stylesheet"

--- a/package.json
+++ b/package.json
@@ -31,13 +31,16 @@
     "access": "public"
   },
   "dependencies": {
-    "@finos/perspective": "^2.2.0",
-    "@finos/perspective-viewer": "^2.1.2",
     "dayjs": "^1.11.8"
   },
+  "peerDependencies": {
+    "@finos/perspective": "^3.8.0",
+    "@finos/perspective-viewer": "^3.8.0"
+  },
   "devDependencies": {
-    "@finos/perspective-esbuild-plugin": "^3.2.1",
-    "@finos/perspective-workspace": "^2.1.2",
+    "@finos/perspective": "^3.8.0",
+    "@finos/perspective-viewer": "^3.8.0",
+    "@finos/perspective-workspace": "^3.8.0",
     "@playwright/test": "^1.36.2",
     "@prospective.co/procss": "^0.1.13",
     "esbuild": "^0.25.0",

--- a/src/js/plugin.js
+++ b/src/js/plugin.js
@@ -112,7 +112,13 @@ export class PerspectiveViewerSummaryPluginElement extends HTMLElement {
 
   async render(view) {
     // pull config
-    const config = await view.get_config();
+
+    // TODO(texodus): This is a bug in Perspective 3.x, fixed
+    // [here](https://github.com/finos/perspective/pull/3053). This can be
+    // be changed back by updating the bounds to 3.8.1
+
+    // const config = await view.get_config();
+    const config = await this.parentElement.save();
 
     this._config = {
       ...this._config,


### PR DESCRIPTION
This PR updates `perspective-summary` to be compatible with Perspective 3:

- The API for `perspective.worker()` is now async, this has been updated in the example projects.
- Example projects updated to use load-order-preserving module syntax.
- Updat call to `View::get_config` which fails to serialize aggregates (see https://github.com/finos/perspective/pull/3053). This has been replaced with `HTMLPerspectiveViewerElement::save`, which does the same thing, but this can be reverted by upgrading to the soon-to-be-released Perspective `3.8.1`. This was caught thanks to @timkpaine's excellent tests for this plugin!
- Updated the `package.json` definition to pin to Perspective `3.8.0`, as well as moving these `dependencies` to `peerDependencies` (as the package itself does not import perspective directly).